### PR TITLE
Fixed spamming chat

### DIFF
--- a/src/main/java/tbsc/clickmod/Compat.java
+++ b/src/main/java/tbsc/clickmod/Compat.java
@@ -55,14 +55,14 @@ public class Compat {
 
             /* AUTO RIGHT CLICK */
 
-            if (!mod.isInGame()) {
-                // Right clicking has probably caused a GUI to open, stop auto clicking
-                mod.sendMessage("Auto right clicking has stopped because a GUI opened");
-                shouldRightClick = false;
-            }
+
 
             if (shouldRightClick) {
-                if (rightCooldown == 0) {
+                if (!mod.isInGame()) {
+                    // Right clicking has probably caused a GUI to open, stop auto clicking
+                    mod.sendMessage("Auto right clicking has stopped because a GUI opened");
+                    shouldRightClick = false;
+                } else if (rightCooldown == 0) {
                     mcReflRightClick();
                     rightCooldown = clickTickInterval - 1;
                 } else {


### PR DESCRIPTION
Previously it would spam "Auto right clicking has stopped because a GUI opened" in the chat whenever you open a GUI; even if auto right clicking is disabled.
this commit fixes that.